### PR TITLE
Ajout du code pour simuler le nombre d'éléments qui peuvent être livrés

### DIFF
--- a/Facilite.MonteCarlo.Core.Tests/Facilite.MonteCarlo.Core.Tests.csproj
+++ b/Facilite.MonteCarlo.Core.Tests/Facilite.MonteCarlo.Core.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="PercentileTest.cs" />
     <Compile Include="SimulationNumberOfDaysTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimulationNumberOfItemsTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Facilite.MonteCarlo.Core.Tests/SimulationNumberOfItemsTest.cs
+++ b/Facilite.MonteCarlo.Core.Tests/SimulationNumberOfItemsTest.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Facilite.MonteCarlo.Core.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Ploeh.AutoFixture;
+
+namespace Facilite.MonteCarlo.Core.Tests
+{
+    [TestClass]
+    public class SimulationNumberOfItemsTest
+    {
+        private Fixture _fixture;
+
+        private Simulation _simulation;
+        private int[] _historicalThroughput;
+        private Mock<ThroughputReader> _mockHistoricalThroughput;
+        private Mock<SimulationResultsWriter> _mockResultsWriter;
+
+        [TestInitialize()]
+        public void Test_Initialize()
+        {
+            _fixture = new Fixture();
+        }
+
+        [TestMethod]
+        public void Execute_Valid_ResultsExpected()
+        {
+            // Arrange
+            CreateMockObjects();
+            CreateSimulationForNumberOfItems();
+
+            _simulation.Initialize();
+
+            // Act
+            _simulation.Execute();
+
+            // Assert
+            _mockHistoricalThroughput.Verify(t => t.GetHistoricalThroughput(), Times.Once);
+            AssertEmptyForecast();
+        }
+
+        [TestMethod]
+        public void CreateForecasts_Valid_FiveExpected()
+        {
+            // Arrange
+            CreateMockObjects();
+            CreateSimulationForNumberOfItems();
+
+            _simulation.Initialize();
+            _simulation.Execute();
+
+            // Act
+            _simulation.CreateForecasts();
+
+            // Assert
+            _mockHistoricalThroughput.Verify(t => t.GetHistoricalThroughput(), Times.Once);
+            AssertNonEmptyForecast();
+        }
+
+        private void CreateMockObjects()
+        {
+            _mockHistoricalThroughput = new Mock<ThroughputReader>();
+            _mockResultsWriter = new Mock<SimulationResultsWriter>();
+
+            _historicalThroughput = new int[] { 2, 7, 3, 9, 0, 3, 6, 8, 3 };
+
+            _mockHistoricalThroughput.Setup<int[]>(t => t.GetHistoricalThroughput()).Returns(_historicalThroughput);
+        }
+
+        private void CreateSimulationForNumberOfItems()
+        {
+            _simulation = new SimulationNumberOfItems(
+                _fixture.Create<int>(),
+                _fixture.Create<int>(),
+                _mockHistoricalThroughput.Object,
+                _mockResultsWriter.Object);
+        }
+
+        private void AssertEmptyForecast()
+        {
+            Assert.IsNotNull(_simulation.Forecasts);
+            Assert.AreEqual<int>(0, _simulation.Forecasts.Count);
+        }
+
+        private void AssertNonEmptyForecast()
+        {
+            Assert.IsNotNull(_simulation.Forecasts);
+            Assert.IsTrue(_simulation.Forecasts.Count > 0);
+        }
+
+    }
+}

--- a/Facilite.MonteCarlo.Core/ForecastDate.cs
+++ b/Facilite.MonteCarlo.Core/ForecastDate.cs
@@ -16,7 +16,7 @@ namespace Facilite.MonteCarlo.Core
 
         public override String ToString()
         {
-            return String.Format("On {2}, {1} confidence of completing {0} items",
+            return String.Format("In {2} days, {1} confidence of completing {0} items",
                 new object[] {
                     NumberOfItemsCompleted, // {0}
                     Percentile,             // {1}

--- a/Facilite.MonteCarlo.Core/SimulationNumberOfItems.cs
+++ b/Facilite.MonteCarlo.Core/SimulationNumberOfItems.cs
@@ -1,11 +1,15 @@
 ﻿using System;
+using System.Linq;
 using Facilite.MonteCarlo.Core.IO;
+using System.Collections.Generic;
 
 namespace Facilite.MonteCarlo.Core
 {
     public class SimulationNumberOfItems : Simulation
     {
         private int numberOfItems;
+
+        private Func<SimulationResult, int, int, bool> filterDelegate;
 
         public SimulationNumberOfItems(
             int numberOfItems,
@@ -17,16 +21,61 @@ namespace Facilite.MonteCarlo.Core
                 resultsWriter)
         {
             this.numberOfItems = numberOfItems;
+            filterDelegate = delegate (SimulationResult result, int numberOfItemsCompleted, int numberOfDaysToComplete)
+            {
+                return result.NumberOfDays == numberOfDaysToComplete;
+            };
         }
 
-        public override void CreateForecasts()
+        protected override Func<SimulationResult, int, int, bool> ResultSimulationFilter
         {
-            throw new NotImplementedException();
+            get { return filterDelegate; }
         }
 
         public override void Execute()
         {
-            throw new NotImplementedException();
+            
+            int simulatedNumberOfItemsCompleted;
+            int randomIndex;
+            int daysToReachNumberOfItems;
+            for (int i = 0; i < NumberOfSimulations; i++)
+            {
+                simulatedNumberOfItemsCompleted = 0;
+                daysToReachNumberOfItems = 0;
+                while (simulatedNumberOfItemsCompleted < this.numberOfItems)
+                {
+                    randomIndex = RandomIndexGenerator.Next(0, HistoricalThroughput.Length);
+                    simulatedNumberOfItemsCompleted += HistoricalThroughput[randomIndex];
+                    daysToReachNumberOfItems++;
+                }
+
+                AddResultSimulation(this.numberOfItems, daysToReachNumberOfItems);
+            }
         }
+
+        public override void CreateForecasts()
+        {
+            var orderedResults = SimulationResults.OrderBy(r => r.NumberOfDays);
+            List<Percentile> percentilesOrdered = Percentiles.OrderBy(p => p.Value).ToList<Percentile>();
+            List<int> percentileOccurences = TransformPercentilesToOccurences(percentilesOrdered);
+            int counter = 0;
+
+            foreach (SimulationResult result in orderedResults)
+            {
+                counter += result.Occurences;
+                if (counter >= percentileOccurences[0])
+                {
+                    Forecasts.Add(new ForecastDate(this.numberOfItems, percentilesOrdered[0], result.NumberOfDays));
+
+                    percentileOccurences.RemoveAt(0);
+                    percentilesOrdered.RemoveAt(0);
+
+                    if (percentileOccurences.Count == 0)
+                        break;                                                                                        
+                }                
+            }
+        }
+
+
     }
 }

--- a/Facilite.MonteCarlo.Core/SimulationResult.cs
+++ b/Facilite.MonteCarlo.Core/SimulationResult.cs
@@ -9,11 +9,13 @@ namespace Facilite.MonteCarlo.Core
     public class SimulationResult
     {
         public int NumberOfItemsCompleted { get; }
+        public int NumberOfDays { get; }
         public int Occurences { get; private set; }
 
-        public SimulationResult(int numberOfItemsCompleted)
+        public SimulationResult(int numberOfItemsCompleted, int numberOfDays)
         {
             this.NumberOfItemsCompleted = numberOfItemsCompleted;
+            this.NumberOfDays = numberOfDays;
             this.Occurences = 1;
         }
 
@@ -24,7 +26,10 @@ namespace Facilite.MonteCarlo.Core
 
         public override string ToString()
         {
-            return String.Format("{0} happened {1} times", NumberOfItemsCompleted, Occurences);
+            return String.Format("{0} items delivered in {1} days [{2} occurences]", 
+                NumberOfItemsCompleted,
+                NumberOfDays,
+                Occurences);
         }
     }
 }


### PR DESCRIPTION
Ajout du code dans SimulationNumberOfItems pour effectuer les simulations afin de donner des percentiles sur la date de livraison possible lorsqu'on fixe le nombre d'éléments à livrer.